### PR TITLE
Docker Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,48 @@ To proper use this software, here is the checklist:
 
 Now simply run it and add a shop inside tinfoil with the address setup in `config` (or `http://localIp:3000` if not specified).
 
+# 🐋 Docker
+
+To run with [Docker](https://docs.docker.com/engine/install/), you can use this as a starting `cli` example:
+
+`docker run -d --restart=always -e TINSHOP_SOURCES_DIRECTORIES=/games -e TINSHOP_WELCOMEMESSAGE="Welcome to my Tinshop!" -v /local/game/backups:/games -p 3000:3000`
+
+This will run Tinshop on  `http://localhost:3000` and persist across reboots!
+
+If `docker compose` is your thing, then start with this example:
+
+```yaml
+version: '3.9'
+services:
+  tinshop:
+    container_name: tinshop
+    image: helvio/tinshop:latest
+    restart: always
+    ports:
+      - 3000:3000
+    environment:
+      - TINSHOP_SOURCES_DIRECTORIES=/games
+      - TINSHOP_WELCOMEMESSAGE=Welcome to my Tinshop!
+    volumes:
+      - /media/switch:/games
+```
+All of the settings in the `config.yaml` file are valid Environment Variables. They must be `UPPERCASE` and prefixed by `TINSHOP_`. Nested properties should be prefixed by `_`. Here are a few examples:
+
+| ENV_VAR                     | `config.yaml` entry | Default Value                  | Example Value                  |
+|-----------------------------|---------------------|--------------------------------|--------------------------------|
+| TINSHOP_HOST                | host                | `0.0.0.0`                      | `127.0.0.`                     |
+| TINSHOP_PROTOCOL            | protocol            | `http`                         | `https`                        |
+| TINSHOP_NAME                | name                | `TinShop`                      | `MyShop`                       |
+| TINSHOP_REVERSEPROXY        | reverseProxy        | `false`                        | `true`                         |
+| TINSHOP_WELCOMEMESSAGE      | welcomeMessage      | `Welcome to your own TinShop!` | `Welcome to my shop!`          |
+| TINSHOP_NOWELCOMEMESSAGE    | noWelcomeMessage    | `false`                        | `true`                         |
+| TINSHOP_DEBUG_NFS           | debug.nfs           | `false`                        | `true`                         |
+| TINSHOP_DEBUG_NOSECURITY    | debug.nosecurity    | `false`                        | `true`                         |
+| TINSHOP_DEBUG_TICKET        | debug.ticket        | `false`                        | `true`                         |
+| TINSHOP_NSP_CHECKVERIFIED   | nsp.checkVerified   | `true`                         | `false`                        |
+| TINSHOP_SOURCES_DIRECTORIES | sources.directories | `./games`                      | `/games`                       |
+| TINSHOP_SOURCES_NSF         | sources.nfs         | `null`                         | `192.168.1.100:/path/to/games` |
+
 # 🎉 Features
 
 Here is the list of all main features so far:
@@ -148,6 +190,38 @@ reverseProxy: true
 ```
 
 If you want to have HTTPS, ensure `caddy` handle it (it will with Let's Encrypt) and change `https` in the config and remove `:80` in the `Caddyfile` example.
+</details>
+
+### Example for traefik
+
+To work with [`traefik`](https://traefik.io/), you need to put in your Dynamic Configuration something similar to this:
+
+```yaml
+http:
+  routers:
+    service: tinshop
+    rule: Host(`tinshop.example.com`)
+    entryPoints: websecure # Could be web if not using https
+
+  services:
+    tinshop:
+      loadBalancer:
+        servers:
+          - url: http://192.168.1.2:3000
+```
+
+and your `config.yaml` as follow:
+
+```yaml
+host: tinshop.example.com
+protocol: http
+port: 3000
+reverseProxy: true
+```
+
+If you want to have HTTPS, ensure `traefik` handle it (it will with Let's Encrypt) and change `https` in the config and remove `:80` in the `Caddyfile` example.
+
+For more details on Traefik + Let's Encrypt, [click here](https://doc.traefik.io/traefik/https/acme/).
 </details>
 
 ## How can I add a `basic auth` to protect my shop?

--- a/README.md
+++ b/README.md
@@ -32,6 +32,41 @@ To proper use this software, here is the checklist:
 
 Now simply run it and add a shop inside tinfoil with the address setup in `config` (or `http://localIp:3000` if not specified).
 
+# 🎉 Features
+
+Here is the list of all main features so far:
+- [X] Automatically download `titles.US.en.json` if missing at startup
+- [X] Basic protection from forged queries (should allow only tinfoil to use the shop)
+- [X] Serve from several mounted directories
+- [X] Serve from several network directories (Using NFS)
+- [X] Display a webpage for forbidden devices
+- [X] Auto-refresh configuration on file change
+- [X] Add the possibility to whitelist or blacklist a switch
+- [X] Add the possibility to ban theme
+- [X] You can specify custom titledb to be merged with official one
+- [X] Auto-watch for mounted directories
+- [X] Add filters path for shop
+- [X] Simple ticket check in NSP/NSZ (based on titledb file)
+- [X] Collect basic statistics
+- [X] An API to query information about your shop
+- [X] Handle Basic Auth from Tinfoil through Forward Auth Endpoint
+
+## 🏳️ Filtering
+
+When you setup your shop inside `tinfoil` you can now add the following path:
+- `multi` : Filter only multiplayer games
+- `fr`, `en`, ... : Filter by languages
+- `world` : All games without any filter (equivalent without path)
+
+# 🧱 Dev or build from source
+
+I suggest to use a tiny executable [gow](https://github.com/mitranim/gow) to help you during the process (hot reload, etc..).  
+For example I use the following command to develop `gow -c run .`.
+
+If you want to build `TinShop` from source, please run `go build`.
+
+And then, simply run `./tinshop`.
+
 # 🐋 Docker
 
 To run with [Docker](https://docs.docker.com/engine/install/), you can use this as a starting `cli` example:
@@ -77,41 +112,6 @@ All of the settings in the `config.yaml` file are valid Environment Variables. T
 | TINSHOP_SECURITY_WHITELIST   | sources.whitelist   | `null`                         | `NSWID1 NSWID2 NSWID3`            |
 | TINSHOP_SECURITY_BLACKLIST   | sources.blacklist   | `null`                         | `NSWID4 NSWID5 NSWID6`            |
 | TINSHOP_SECURITY_FORWARDAUTH | sources.forwardAuth | `null`                         | `https://auth.tinshop.com/switch` |
-
-# 🎉 Features
-
-Here is the list of all main features so far:
-- [X] Automatically download `titles.US.en.json` if missing at startup
-- [X] Basic protection from forged queries (should allow only tinfoil to use the shop)
-- [X] Serve from several mounted directories
-- [X] Serve from several network directories (Using NFS)
-- [X] Display a webpage for forbidden devices
-- [X] Auto-refresh configuration on file change
-- [X] Add the possibility to whitelist or blacklist a switch
-- [X] Add the possibility to ban theme
-- [X] You can specify custom titledb to be merged with official one
-- [X] Auto-watch for mounted directories
-- [X] Add filters path for shop
-- [X] Simple ticket check in NSP/NSZ (based on titledb file)
-- [X] Collect basic statistics
-- [X] An API to query information about your shop
-- [X] Handle Basic Auth from Tinfoil through Forward Auth Endpoint
-
-## 🏳️ Filtering
-
-When you setup your shop inside `tinfoil` you can now add the following path:
-- `multi` : Filter only multiplayer games
-- `fr`, `en`, ... : Filter by languages
-- `world` : All games without any filter (equivalent without path)
-
-# 🧱 Dev or build from source
-
-I suggest to use a tiny executable [gow](https://github.com/mitranim/gow) to help you during the process (hot reload, etc..).  
-For example I use the following command to develop `gow -c run .`.
-
-If you want to build `TinShop` from source, please run `go build`.
-
-And then, simply run `./tinshop`.
 
 ## 🥍 Want to do cross-build generation?
 

--- a/README.md
+++ b/README.md
@@ -59,20 +59,24 @@ services:
 ```
 All of the settings in the `config.yaml` file are valid Environment Variables. They must be `UPPERCASE` and prefixed by `TINSHOP_`. Nested properties should be prefixed by `_`. Here are a few examples:
 
-| ENV_VAR                     | `config.yaml` entry | Default Value                  | Example Value                  |
-|-----------------------------|---------------------|--------------------------------|--------------------------------|
-| TINSHOP_HOST                | host                | `0.0.0.0`                      | `127.0.0.`                     |
-| TINSHOP_PROTOCOL            | protocol            | `http`                         | `https`                        |
-| TINSHOP_NAME                | name                | `TinShop`                      | `MyShop`                       |
-| TINSHOP_REVERSEPROXY        | reverseProxy        | `false`                        | `true`                         |
-| TINSHOP_WELCOMEMESSAGE      | welcomeMessage      | `Welcome to your own TinShop!` | `Welcome to my shop!`          |
-| TINSHOP_NOWELCOMEMESSAGE    | noWelcomeMessage    | `false`                        | `true`                         |
-| TINSHOP_DEBUG_NFS           | debug.nfs           | `false`                        | `true`                         |
-| TINSHOP_DEBUG_NOSECURITY    | debug.nosecurity    | `false`                        | `true`                         |
-| TINSHOP_DEBUG_TICKET        | debug.ticket        | `false`                        | `true`                         |
-| TINSHOP_NSP_CHECKVERIFIED   | nsp.checkVerified   | `true`                         | `false`                        |
-| TINSHOP_SOURCES_DIRECTORIES | sources.directories | `./games`                      | `/games`                       |
-| TINSHOP_SOURCES_NSF         | sources.nfs         | `null`                         | `192.168.1.100:/path/to/games` |
+| ENV_VAR                      | `config.yaml` entry | Default Value                  | Example Value                     |
+|------------------------------|---------------------|--------------------------------|-----------------------------------|
+| TINSHOP_HOST                 | host                | `0.0.0.0`                      | `127.0.0.`                        |
+| TINSHOP_PROTOCOL             | protocol            | `http`                         | `https`                           |
+| TINSHOP_NAME                 | name                | `TinShop`                      | `MyShop`                          |
+| TINSHOP_REVERSEPROXY         | reverseProxy        | `false`                        | `true`                            |
+| TINSHOP_WELCOMEMESSAGE       | welcomeMessage      | `Welcome to your own TinShop!` | `Welcome to my shop!`             |
+| TINSHOP_NOWELCOMEMESSAGE     | noWelcomeMessage    | `false`                        | `true`                            |
+| TINSHOP_DEBUG_NFS            | debug.nfs           | `false`                        | `true`                            |
+| TINSHOP_DEBUG_NOSECURITY     | debug.nosecurity    | `false`                        | `true`                            |
+| TINSHOP_DEBUG_TICKET         | debug.ticket        | `false`                        | `true`                            |
+| TINSHOP_NSP_CHECKVERIFIED    | nsp.checkVerified   | `true`                         | `false`                           |
+| TINSHOP_SOURCES_DIRECTORIES  | sources.directories | `./games`                      | `/games /path/two /path/three`    |
+| TINSHOP_SOURCES_NSF          | sources.nfs         | `null`                         | `192.168.1.100:/path/to/games`    |
+| TINSHOP_SECURITY_BANNEDTHEME | sources.bannedTheme | `null`                         | `THEME1 THEME2 THEME3`            |
+| TINSHOP_SECURITY_WHITELIST   | sources.whitelist   | `null`                         | `NSWID1 NSWID2 NSWID3`            |
+| TINSHOP_SECURITY_BLACKLIST   | sources.blacklist   | `null`                         | `NSWID4 NSWID5 NSWID6`            |
+| TINSHOP_SECURITY_FORWARDAUTH | sources.forwardAuth | `null`                         | `https://auth.tinshop.com/switch` |
 
 # 🎉 Features
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ All of the settings in the `config.yaml` file are valid Environment Variables. T
 
 | ENV_VAR                      | `config.yaml` entry | Default Value                  | Example Value                     |
 |------------------------------|---------------------|--------------------------------|-----------------------------------|
-| TINSHOP_HOST                 | host                | `0.0.0.0`                      | `127.0.0.`                        |
+| TINSHOP_HOST                 | host                | `<empty>`                      | `tinshop.example.com`             |
 | TINSHOP_PROTOCOL             | protocol            | `http`                         | `https`                           |
 | TINSHOP_NAME                 | name                | `TinShop`                      | `MyShop`                          |
 | TINSHOP_REVERSEPROXY         | reverseProxy        | `false`                        | `true`                            |
@@ -70,7 +70,7 @@ All of the settings in the `config.yaml` file are valid Environment Variables. T
 | TINSHOP_DEBUG_NFS            | debug.nfs           | `false`                        | `true`                            |
 | TINSHOP_DEBUG_NOSECURITY     | debug.nosecurity    | `false`                        | `true`                            |
 | TINSHOP_DEBUG_TICKET         | debug.ticket        | `false`                        | `true`                            |
-| TINSHOP_NSP_CHECKVERIFIED    | nsp.checkVerified   | `true`                         | `false`                           |
+| TINSHOP_NSP_CHECKVERIFIED    | nsp.checkVerified   | `false`                        | `true`                            |
 | TINSHOP_SOURCES_DIRECTORIES  | sources.directories | `./games`                      | `/games /path/two /path/three`    |
 | TINSHOP_SOURCES_NSF          | sources.nfs         | `null`                         | `192.168.1.100:/path/to/games`    |
 | TINSHOP_SECURITY_BANNEDTHEME | sources.bannedTheme | `null`                         | `THEME1 THEME2 THEME3`            |
@@ -222,7 +222,7 @@ port: 3000
 reverseProxy: true
 ```
 
-If you want to have HTTPS, ensure `traefik` handle it (it will with Let's Encrypt) and change `https` in the config and remove `:80` in the `Caddyfile` example.
+If you want to have HTTPS, ensure `traefik` can handle it (it will with Let's Encrypt) and use protocol `https` in the config.
 
 For more details on Traefik + Let's Encrypt, [click here](https://doc.traefik.io/traefik/https/acme/).
 </details>

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ reverseProxy: true
 ```
 
 If you want to have HTTPS, ensure `caddy` handle it (it will with Let's Encrypt) and change `https` in the config and remove `:80` in the `Caddyfile` example.
-</details>
 
 ### Example for traefik
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,7 @@ func (cfg *Configuration) LoadConfig() {
 	viper.AddConfigPath(".")          // optionally look for config in the working directory
 	viper.SetTypeByDefaultValue(true) // Allows []string to be parsed from Env Vars
 
-	viper.SetDefault("host", "tinshop.example.com")
+	viper.SetDefault("host", "")
 	viper.SetDefault("protocol", "http")
 	viper.SetDefault("name", "TinShop")
 	viper.SetDefault("reverseProxy", false)
@@ -80,7 +80,7 @@ func (cfg *Configuration) LoadConfig() {
 	viper.SetDefault("debug.noSecurity", false)
 	viper.SetDefault("debug.ticket", false)
 
-	viper.SetDefault("nsp.checkVerified", true)
+	viper.SetDefault("nsp.checkVerified", false)
 
 	viper.SetDefault("sources.directories", []string{"./games"})
 	viper.SetDefault("sources.nfs", []string{})

--- a/config/config.go
+++ b/config/config.go
@@ -36,8 +36,8 @@ type nsp struct {
 	CheckVerified bool `mapstructure:"checkVerified"`
 }
 
-// File holds all config information
-type File struct {
+// Configuration holds all config information
+type Configuration struct {
 	rootShop             string
 	ShopHost             string                             `mapstructure:"host"`
 	ShopProtocol         string                             `mapstructure:"protocol"`
@@ -59,11 +59,11 @@ type File struct {
 
 // New returns a new configuration
 func New() repository.Config {
-	return &File{}
+	return &Configuration{}
 }
 
 // LoadConfig handles viper under the hood
-func (cfg *File) LoadConfig() {
+func (cfg *Configuration) LoadConfig() {
 	viper.SetConfigName("config")     // name of config file (without extension)
 	viper.SetConfigType("yaml")       // REQUIRED if the config file does not have the extension in the name
 	viper.AddConfigPath(".")          // optionally look for config in the working directory
@@ -113,7 +113,7 @@ func (cfg *File) LoadConfig() {
 	cfg.configChange()
 }
 
-func (cfg *File) configChange() {
+func (cfg *Configuration) configChange() {
 	// Call all before hooks
 	for _, hook := range cfg.beforeAllHooks {
 		hook(cfg)
@@ -145,8 +145,8 @@ func (cfg *File) configChange() {
 	}
 }
 
-func loadAndCompute() *File {
-	var loadedConfig = &File{}
+func loadAndCompute() *Configuration {
+	var loadedConfig = &Configuration{}
 	err := viper.Unmarshal(&loadedConfig)
 
 	if err != nil {
@@ -204,117 +204,117 @@ func ComputeDefaultValues(config repository.Config) repository.Config {
 }
 
 // AddHook Add hook function on change config
-func (cfg *File) AddHook(f func(repository.Config)) {
+func (cfg *Configuration) AddHook(f func(repository.Config)) {
 	cfg.allHooks = append(cfg.allHooks, f)
 }
 
 // AddBeforeHook Add hook function before on change config
-func (cfg *File) AddBeforeHook(f func(repository.Config)) {
+func (cfg *Configuration) AddBeforeHook(f func(repository.Config)) {
 	cfg.beforeAllHooks = append(cfg.beforeAllHooks, f)
 }
 
 // SetRootShop allow to change the root url of the shop
-func (cfg *File) SetRootShop(root string) {
+func (cfg *Configuration) SetRootShop(root string) {
 	cfg.rootShop = root
 }
 
 // RootShop returns the RootShop url
-func (cfg *File) RootShop() string {
+func (cfg *Configuration) RootShop() string {
 	return cfg.rootShop
 }
 
 // ReverseProxy returns the ReverseProxy setting
-func (cfg *File) ReverseProxy() bool {
+func (cfg *Configuration) ReverseProxy() bool {
 	return cfg.Proxy
 }
 
 // WelcomeMessage returns the WelcomeMessage
-func (cfg *File) WelcomeMessage() string {
+func (cfg *Configuration) WelcomeMessage() string {
 	return cfg.ShopWelcomeMessage
 }
 
 // NoWelcomeMessage returns the NoWelcomeMessage
-func (cfg *File) NoWelcomeMessage() bool {
+func (cfg *Configuration) NoWelcomeMessage() bool {
 	return cfg.ShopNoWelcomeMessage
 }
 
 // Protocol returns the protocol scheme (http or https)
-func (cfg *File) Protocol() string {
+func (cfg *Configuration) Protocol() string {
 	return cfg.ShopProtocol
 }
 
 // Host returns the host of the shop
-func (cfg *File) Host() string {
+func (cfg *Configuration) Host() string {
 	return cfg.ShopHost
 }
 
 // Port returns the port number for outside access
-func (cfg *File) Port() int {
+func (cfg *Configuration) Port() int {
 	return cfg.ShopPort
 }
 
 // DebugTicket tells if we should display additional log for ticket verification
-func (cfg *File) DebugTicket() bool {
+func (cfg *Configuration) DebugTicket() bool {
 	return cfg.Debug.Ticket
 }
 
 // DebugNfs tells if we should display additional log for nfs
-func (cfg *File) DebugNfs() bool {
+func (cfg *Configuration) DebugNfs() bool {
 	return cfg.Debug.Nfs
 }
 
 // DebugNoSecurity returns if we should disable security or not
-func (cfg *File) DebugNoSecurity() bool {
+func (cfg *Configuration) DebugNoSecurity() bool {
 	return cfg.Debug.NoSecurity
 }
 
 // Directories returns the list of directories sources
-func (cfg *File) Directories() []string {
+func (cfg *Configuration) Directories() []string {
 	return cfg.AllSources.Directories
 }
 
 // CustomDB returns the list of custom title db
-func (cfg *File) CustomDB() map[string]repository.TitleDBEntry {
+func (cfg *Configuration) CustomDB() map[string]repository.TitleDBEntry {
 	return cfg.CustomTitleDB
 }
 
 // NfsShares returns the list of nfs sources
-func (cfg *File) NfsShares() []string {
+func (cfg *Configuration) NfsShares() []string {
 	return cfg.AllSources.Nfs
 }
 
 // Sources returns all available sources
-func (cfg *File) Sources() repository.ConfigSources {
+func (cfg *Configuration) Sources() repository.ConfigSources {
 	return cfg.AllSources
 }
 
 // ShopTemplateData returns the data needed to render template
-func (cfg *File) ShopTemplateData() repository.ShopTemplate {
+func (cfg *Configuration) ShopTemplateData() repository.ShopTemplate {
 	return cfg.shopTemplateData
 }
 
 // SetShopTemplateData sets the data for template
-func (cfg *File) SetShopTemplateData(data repository.ShopTemplate) {
+func (cfg *Configuration) SetShopTemplateData(data repository.ShopTemplate) {
 	cfg.shopTemplateData = data
 }
 
 // ShopTitle returns the name of the shop
-func (cfg *File) ShopTitle() string {
+func (cfg *Configuration) ShopTitle() string {
 	return cfg.Name
 }
 
 // VerifyNSP tells if we need to verify NSP
-func (cfg *File) VerifyNSP() bool {
+func (cfg *Configuration) VerifyNSP() bool {
 	return cfg.NSP.CheckVerified
 }
 
 // ForwardAuthURL returns the url of the forward auth
-func (cfg *File) ForwardAuthURL() string {
+func (cfg *Configuration) ForwardAuthURL() string {
 	return cfg.Security.ForwardAuth
 }
 
 // IsBlacklisted tells if the uid is blacklisted or not
-func (cfg *File) IsBlacklisted(uid string) bool {
+func (cfg *Configuration) IsBlacklisted(uid string) bool {
 	if len(cfg.Security.Whitelist) != 0 {
 		return !cfg.isInWhiteList(uid)
 	}
@@ -322,20 +322,20 @@ func (cfg *File) IsBlacklisted(uid string) bool {
 }
 
 // IsWhitelisted tells if the uid is whitelisted or not
-func (cfg *File) IsWhitelisted(uid string) bool {
+func (cfg *Configuration) IsWhitelisted(uid string) bool {
 	if len(cfg.Security.Whitelist) == 0 {
 		return !cfg.isInBlackList(uid)
 	}
 	return cfg.isInWhiteList(uid)
 }
 
-func (cfg *File) isInBlackList(uid string) bool {
+func (cfg *Configuration) isInBlackList(uid string) bool {
 	idxBlackList := utils.Search(len(cfg.Security.Blacklist), func(index int) bool {
 		return cfg.Security.Blacklist[index] == uid
 	})
 	return idxBlackList != -1
 }
-func (cfg *File) isInWhiteList(uid string) bool {
+func (cfg *Configuration) isInWhiteList(uid string) bool {
 	idxWhiteList := utils.Search(len(cfg.Security.Whitelist), func(index int) bool {
 		return cfg.Security.Whitelist[index] == uid
 	})
@@ -343,7 +343,7 @@ func (cfg *File) isInWhiteList(uid string) bool {
 }
 
 // IsBannedTheme tells if the theme is banned or not
-func (cfg *File) IsBannedTheme(theme string) bool {
+func (cfg *Configuration) IsBannedTheme(theme string) bool {
 	idxBannedTheme := utils.Search(len(cfg.Security.BannedTheme), func(index int) bool {
 		return cfg.Security.BannedTheme[index] == theme
 	})
@@ -351,6 +351,6 @@ func (cfg *File) IsBannedTheme(theme string) bool {
 }
 
 // BannedTheme returns all banned theme
-func (cfg *File) BannedTheme() []string {
+func (cfg *Configuration) BannedTheme() []string {
 	return cfg.Security.BannedTheme
 }

--- a/config/config.go
+++ b/config/config.go
@@ -64,15 +64,37 @@ func New() repository.Config {
 
 // LoadConfig handles viper under the hood
 func (cfg *File) LoadConfig() {
-	viper.SetConfigName("config") // name of config file (without extension)
-	viper.SetConfigType("yaml")   // REQUIRED if the config file does not have the extension in the name
-	viper.AddConfigPath(".")      // optionally look for config in the working directory
-	viper.SetDefault("sources.directories", "./games")
+	viper.SetConfigName("config")     // name of config file (without extension)
+	viper.SetConfigType("yaml")       // REQUIRED if the config file does not have the extension in the name
+	viper.AddConfigPath(".")          // optionally look for config in the working directory
+	viper.SetTypeByDefaultValue(true) // Allows []string to be parsed from Env Vars
+
+	viper.SetDefault("host", "tinshop.example.com")
+	viper.SetDefault("protocol", "http")
+	viper.SetDefault("name", "TinShop")
+	viper.SetDefault("reverseProxy", false)
 	viper.SetDefault("welcomeMessage", "Welcome to your own TinShop!")
 	viper.SetDefault("noWelcomeMessage", false)
+
+	viper.SetDefault("debug.nfs", false)
+	viper.SetDefault("debug.noSecurity", false)
+	viper.SetDefault("debug.ticket", false)
+
+	viper.SetDefault("nsp.checkVerified", true)
+
+	viper.SetDefault("sources.directories", []string{"./games"})
+	viper.SetDefault("sources.nfs", []string{})
+
+	viper.SetDefault("security.bannedTheme", []string{})
+	viper.SetDefault("security.whitelist", []string{})
+	viper.SetDefault("security.blacklist", []string{})
+	viper.SetDefault("security.forwardAuth", "")
+
 	viper.SetEnvPrefix("TINSHOP")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
+
+	viper.SafeWriteConfig()
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/config/config.go
+++ b/config/config.go
@@ -94,8 +94,6 @@ func (cfg *File) LoadConfig() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
-	viper.SafeWriteConfig()
-
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; ignore error if desired

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/DblK/tinshop/repository"
 	"github.com/DblK/tinshop/utils"
@@ -69,6 +70,9 @@ func (cfg *File) LoadConfig() {
 	viper.SetDefault("sources.directories", "./games")
 	viper.SetDefault("welcomeMessage", "Welcome to your own TinShop!")
 	viper.SetDefault("noWelcomeMessage", false)
+	viper.SetEnvPrefix("TINSHOP")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
@@ -169,7 +173,7 @@ func ComputeDefaultValues(config repository.Config) repository.Config {
 			rootShop += ":" + strconv.Itoa(config.Port())
 		}
 	}
-	log.Println((rootShop))
+	log.Println(rootShop)
 	config.SetRootShop(rootShop)
 
 	config.SetShopTemplateData(repository.ShopTemplate{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,10 +175,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Context("Security for Blacklist/Whitelist tests", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		Describe("Blacklist tests", func() { //nolint:dupl
@@ -251,10 +251,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Context("Security for theme", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		Describe("IsBannedTheme", func() {
@@ -276,10 +276,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("Protocol", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -291,10 +291,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("Host", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -306,10 +306,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("WelcomeMessage", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -325,10 +325,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("Port", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -340,10 +340,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("ReverseProxy", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -355,10 +355,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("ShopTitle", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -370,10 +370,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("DebugNfs", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -385,10 +385,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("VerifyNSP", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -400,10 +400,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("DebugNoSecurity", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -415,10 +415,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("DebugTicket", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {
@@ -430,10 +430,10 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("BannedTheme", func() {
-		var myConfig config.File
+		var myConfig config.Configuration
 
 		BeforeEach(func() {
-			myConfig = config.File{}
+			myConfig = config.Configuration{}
 		})
 
 		It("Test with empty object", func() {

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -5,10 +5,23 @@ services:
     build: .
     container_name: app
     restart: unless-stopped
+    environment:
+      - TINSHOP_HOST=tinshop.example.com
+      - TINSHOP_PROTOCOL=https
+      - TINSHOP_NAME=TinShop
+      - TINSHOP_REVERSEPROXY=true
+      - TINSHOP_WELCOMEMESSAGE=Welcome to TinShop!
+      - TINSHOP_NOWELCOMEMESSAGE=false
+      - TINSHOP_DEBUG_NFS=false
+      - TINSHOP_DEBUG_NOSECURITY=false
+      - TINSHOP_DEBUG_TICKET=false
+      - TINSHOP_NSP_CHECKVERIFIED=true
+      - TINSHOP_SOURCES_DIRECTORIES=/games
+      - TINSHOP_SECURITY_WHITELIST=0000000000000000000000000000000000000000000000000000000000000000 1111111111111111111111111111111111111111111111111111111111111111
     ports:
       - 3000:3000
     volumes:
-      - ./config.example.yaml:/config.yaml
+      - /media/switch:/games
       
 
   nginx:

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -237,7 +237,7 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 
 		// Append version when update
 		if update {
-			extra = fmt.Sprintf("[v%d]", title.Version)
+			extra = fmt.Sprintf("[v%d][UPD]", title.Version)
 		}
 
 		// Build the friendly name for Tinfoil

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -221,7 +221,6 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 	var gameList = make([]repository.GameFileType, 0)
 
 	for _, file := range newGames {
-
 		baseID, update, dlc := GetTitleMeta(file.GameID)
 		baseTitle := c.Library()[baseID]
 		title := c.Library()[file.GameID]

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -222,7 +222,7 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 	var gameList = make([]repository.GameFileType, 0)
 
 	for _, file := range newGames {
-		baseID, update, dlc := GetTitleMeta(file.GameID)
+		baseID, update, dlc := utils.GetTitleMeta(file.GameID)
 		baseTitle := c.Library()[baseID]
 		title := c.Library()[file.GameID]
 		extension := filepath.Ext(file.Path)

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -241,7 +241,7 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 		}
 
 		// Build the friendly name for Tinfoil
-		friendlyName := fmt.Sprintf("%s (%s) %s%s", baseTitle.Name, baseTitle.Region, extra, extension)
+		friendlyName := fmt.Sprintf("[%s] %s (%s) %s%s", file.GameID, baseTitle.Name, baseTitle.Region, extra, extension)
 
 		game := repository.GameFileType{
 			URL:  c.config.RootShop() + "/games/" + file.GameID + "#" + c.getFriendlyName(file),

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -221,6 +221,23 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 	var gameList = make([]repository.GameFileType, 0)
 
 	for _, file := range newGames {
+
+		baseID, update, dlc := GetTitleMeta(file.GameID)
+		baseTitle := c.Library()[baseID]
+		title := c.Library()[file.GameID]
+
+		var extra = " [BASE]"
+
+		if dlc {
+			extra = " - " + title.Name + " [DLC]"
+		}
+
+		if update {
+			extra = fmt.Sprintf(" [v%d]", title.Version)
+		}
+
+		log.Println(baseTitle.Name + extra)
+
 		game := repository.GameFileType{
 			URL:  c.config.RootShop() + "/games/" + file.GameID + "#" + c.getFriendlyName(file),
 			Size: file.Size,

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/DblK/tinshop/repository"
@@ -222,27 +221,6 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 	var gameList = make([]repository.GameFileType, 0)
 
 	for _, file := range newGames {
-		baseID, update, dlc := utils.GetTitleMeta(file.GameID)
-		baseTitle := c.Library()[baseID]
-		title := c.Library()[file.GameID]
-		extension := filepath.Ext(file.Path)
-
-		// Default extra for Base title
-		var extra = "[BASE]"
-
-		// Append DLC Name and tag when dlc
-		if dlc {
-			extra = fmt.Sprintf("- %s [DLC]", title.Name)
-		}
-
-		// Append version when update
-		if update {
-			extra = fmt.Sprintf("[v%d][UPD]", title.Version)
-		}
-
-		// Build the friendly name for Tinfoil
-		friendlyName := fmt.Sprintf("[%s] %s (%s) %s%s", file.GameID, baseTitle.Name, baseTitle.Region, extra, extension)
-
 		game := repository.GameFileType{
 			URL:  c.config.RootShop() + "/games/" + file.GameID + "#" + c.getFriendlyName(file),
 			Size: file.Size,

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -235,8 +235,6 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 			extra = fmt.Sprintf(" [v%d]", title.Version)
 		}
 
-		log.Println(baseTitle.Name + extra)
-
 		game := repository.GameFileType{
 			URL:  c.config.RootShop() + "/games/" + file.GameID + "#" + c.getFriendlyName(file),
 			Size: file.Size,

--- a/gamescollection/collection.go
+++ b/gamescollection/collection.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/DblK/tinshop/repository"
@@ -224,16 +225,23 @@ func (c *collect) AddNewGames(newGames []repository.FileDesc) {
 		baseID, update, dlc := GetTitleMeta(file.GameID)
 		baseTitle := c.Library()[baseID]
 		title := c.Library()[file.GameID]
+		extension := filepath.Ext(file.Path)
 
-		var extra = " [BASE]"
+		// Default extra for Base title
+		var extra = "[BASE]"
 
+		// Append DLC Name and tag when dlc
 		if dlc {
-			extra = " - " + title.Name + " [DLC]"
+			extra = fmt.Sprintf("- %s [DLC]", title.Name)
 		}
 
+		// Append version when update
 		if update {
-			extra = fmt.Sprintf(" [v%d]", title.Version)
+			extra = fmt.Sprintf("[v%d]", title.Version)
 		}
+
+		// Build the friendly name for Tinfoil
+		friendlyName := fmt.Sprintf("%s (%s) %s%s", baseTitle.Name, baseTitle.Region, extra, extension)
 
 		game := repository.GameFileType{
 			URL:  c.config.RootShop() + "/games/" + file.GameID + "#" + c.getFriendlyName(file),


### PR DESCRIPTION
This set of commits enables TinShop to run on Docker without the need of a `config.yaml` file mapping.
I am running as a container and without a configuration file. All settings were transported successfully.

According to Viper docs, ENV vars naturally supersede a config file. I mapped all the missing configs on `viper`.